### PR TITLE
Change column name in comments and likes tables

### DIFF
--- a/db/migrate/20230301193358_rename_user_id_to_author_id.rb
+++ b/db/migrate/20230301193358_rename_user_id_to_author_id.rb
@@ -1,0 +1,6 @@
+class RenameUserIdToAuthorId < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :likes, :user_id, :author_id
+    rename_column :comments, :user_id, :author_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_170150) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_01_193358) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,19 +18,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_170150) do
     t.string "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "author_id", null: false
     t.bigint "post_id", null: false
+    t.index ["author_id"], name: "index_comments_on_author_id"
     t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "likes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "author_id", null: false
     t.bigint "post_id", null: false
+    t.index ["author_id"], name: "index_likes_on_author_id"
     t.index ["post_id"], name: "index_likes_on_post_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -54,8 +54,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_170150) do
   end
 
   add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
+  add_foreign_key "comments", "users", column: "author_id"
   add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
+  add_foreign_key "likes", "users", column: "author_id"
   add_foreign_key "posts", "users", column: "author_id"
 end


### PR DESCRIPTION
-Renamed column `user_id` to `author_id` in **comments** and **likes** tables through a migration.